### PR TITLE
Debian support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,6 +76,35 @@ jobs:
           push: ${{ github.ref == 'refs/heads/master' }}
           tags: ghcr.io/${{ env.REPO_NAME }}/deps:ubuntu${{ matrix.os }}
           build-args: OS_VERSION=${{ matrix.os }}
+
+  debian:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - 10 # Buster
+          - 11 # Bullseye
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to the container registry
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}                
+          username: ${{ env.REPO_NAME }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and optional Push Debian ${{ matrix.os }} Container
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile.debian
+          push: ${{ github.ref == 'refs/heads/master' }}
+          tags: ghcr.io/${{ env.REPO_NAME }}/deps:debian${{ matrix.os }}
+          build-args: OS_VERSION=${{ matrix.os }}
+
   fedora:
     runs-on: ubuntu-latest
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*~
+*.xcodeproj
+.vs

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,31 @@
+ARG OS_VERSION
+## Use the official Debian <OS_VERSION> Image from Dockerhub
+FROM docker.io/library/debian:${OS_VERSION}
+
+## Set up environment variables so the tzdata install doesn't
+## hang on asking for user input for configuration
+ARG DEBIAN_FRONTEND="noninteractive"
+ARG TZ="America/New_York"
+
+## Install the deps and create the build directory
+RUN apt-get update &&\
+    apt-get install -y --no-install-recommends git cmake build-essential \
+      gettext help2man libopenblas-dev libfftw3-dev libicu-dev libepoxy-dev \
+      libsdl2-dev libfreetype6-dev libpango1.0-dev librsvg2-dev libxml++2.6-dev \
+      libavcodec-dev libavformat-dev libswscale-dev libjpeg-dev \
+      portaudio19-dev libglm-dev libboost-filesystem-dev \
+      libboost-iostreams-dev libboost-locale-dev libboost-system-dev \
+      libboost-program-options-dev libssl-dev libcpprest-dev \
+      libportmidi-dev libopencv-dev libaubio-dev nlohmann-json3-dev python3 python3-pip \
+      python3-setuptools python3-wheel file ninja-build && \
+    pip3 install --user meson && \
+    apt-get clean && \
+    mkdir /root/performous
+
+## Add the meson installation to the path
+ENV PATH=/root/.local/bin:$PATH
+
+## Copy in the build script to make things easy
+COPY build_performous.sh /root/performous/build_performous.sh
+
+WORKDIR /root/performous

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ docker build -t performous-docker-build:ubuntu20.04 -f Dockerfile.ubuntu --build
 Currently supported distros are:
 - Ubuntu (18.04, 20.04, 22.04)
 - Fedora (33, 34, 35)
+- Debian (10, 11)
 
 ## Running the containers
 Once the `base-image` has been built, the container can be run interactively to build `Performous`:  


### PR DESCRIPTION
## Changes
Adds debian support for the 2 LTS versions 10 (buster) and 11 (bullseye)

I didn't include version 9 since it'll reach EOL june 30th 2022. 

## Blocked by
This PR is blocked by https://github.com/performous/performous-docker/pull/12