### PR TITLE
Added Fedora 36

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -113,6 +113,7 @@ jobs:
           - 33
           - 34
           - 35
+          - 36
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -16,9 +16,7 @@ RUN apt-get update &&\
       portaudio19-dev libglm-dev libboost-filesystem-dev \
       libboost-iostreams-dev libboost-locale-dev libboost-system-dev \
       libboost-program-options-dev libssl-dev libcpprest-dev \
-      libportmidi-dev libopencv-dev libaubio-dev nlohmann-json3-dev python3 python3-pip \
-      python3-setuptools python3-wheel file ninja-build && \
-    pip3 install --user meson && \
+      libportmidi-dev libopencv-dev libaubio-dev nlohmann-json3-dev && \
     apt-get clean && \
     mkdir /root/performous
 

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -9,8 +9,7 @@ RUN dnf install -y https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-rele
         glibmm24-devel libxml++-devel boost-devel SDL2-devel libepoxy-devel ffmpeg-devel \
         portaudio-devel help2man redhat-lsb opencv-devel portmidi-devel libjpeg-turbo-devel \
         pango-devel jsoncpp-devel glm-devel openblas-devel fftw-devel cpprest-devel \
-        aubio-devel json-devel python3-pip rpm-build && \
-    pip3 install meson ninja && \
+        aubio-devel json-devel rpm-build && \
     dnf clean all && \
     mkdir /root/performous
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -16,9 +16,7 @@ RUN apt-get update &&\
       portaudio19-dev libglm-dev libboost-filesystem-dev \
       libboost-iostreams-dev libboost-locale-dev libboost-system-dev \
       libboost-program-options-dev libssl-dev libcpprest-dev \
-      libportmidi-dev libopencv-dev libaubio-dev nlohmann-json3-dev python-is-python3 python3-pip \
-      python3-setuptools python3-wheel file ninja-build && \
-    pip3 install --user meson && \
+      libportmidi-dev libopencv-dev libaubio-dev nlohmann-json3-dev && \
     apt-get clean && \
     mkdir /root/performous
 

--- a/Dockerfile.ubuntu18.04
+++ b/Dockerfile.ubuntu18.04
@@ -21,12 +21,8 @@ RUN apt-get update && apt-get install -y wget gpg software-properties-common &&\
       portaudio19-dev libglm-dev libboost-filesystem-dev\
       libboost-iostreams-dev libboost-locale-dev libboost-system-dev\
       libboost-program-options-dev libssl-dev libcpprest-dev libportmidi-dev\
-      libopencv-dev libaubio-dev nlohmann-json-dev python3 python3-pip python3-setuptools\
-      python3-wheel ninja-build file &&\
-    pip3 install --user meson &&\
+      libopencv-dev libaubio-dev nlohmann-json-dev && \
     apt-get clean &&\
-    ## Set python to python3
-    update-alternatives --install /usr/bin/python python /usr/bin/python3.6 10 &&\
     mkdir /root/performous
 
 ## Set the default compiler that cmake will use, otherwise it throws an error.


### PR DESCRIPTION
## Changes
Added fedora 36
Removes meson support since https://github.com/performous/performous/pull/734 got merged to master.

# notes

Didn't build/run Performous itself on fedora 36 so please verify it first before merging