### PR TITLE
Retire Fedora 33

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -151,7 +151,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - 33
           - 34
           - 35
           - 36


### PR DESCRIPTION
This will need to be merged after https://github.com/performous/performous/pull/753 is merged, and this repo will need to updated to remove `Fedora 33` as a required check, and `Fedora 36` will need to be added.