### PR TITLE
Add/libfmt

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -27,7 +27,7 @@ RUN if [ ${OS_VERSION} -eq 10 ]; then\
       libboost-iostreams-dev libboost-locale-dev libboost-system-dev \
       libboost-program-options-dev libssl-dev libcpprest-dev \
       libportmidi-dev libopencv-dev libaubio-dev nlohmann-json3-dev \
-      ca-certificates file && \
+      libfmt-dev ca-certificates file && \
     apt-get clean && \
     mkdir /root/performous
 

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -9,7 +9,7 @@ RUN dnf install -y https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-rele
         glibmm24-devel libxml++-devel boost-devel SDL2-devel libepoxy-devel ffmpeg-devel \
         portaudio-devel help2man redhat-lsb opencv-devel portmidi-devel libjpeg-turbo-devel \
         pango-devel jsoncpp-devel glm-devel openblas-devel fftw-devel cpprest-devel \
-        aubio-devel json-devel rpm-build && \
+        aubio-devel json-devel rpm-build fmt-devel && \
     dnf clean all && \
     mkdir /root/performous
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -29,7 +29,7 @@ RUN apt-get install -y --no-install-recommends git cmake build-essential \
       libboost-iostreams-dev libboost-locale-dev libboost-system-dev \
       libboost-program-options-dev libssl-dev libcpprest-dev \
       libportmidi-dev libopencv-dev libaubio-dev \
-      ca-certificates file && \
+      libfmt-dev ca-certificates file && \
     apt-get clean && \
     mkdir /root/performous
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ docker build -t performous-docker-build:ubuntu20.04 -f Dockerfile.ubuntu --build
 
 Currently supported distros are:
 - Ubuntu (18.04, 20.04, 22.04)
-- Fedora (33, 34, 35)
+- Fedora (34, 35, 36)
 - Debian (10, 11)
 
 ## Running the containers


### PR DESCRIPTION
Adds libfmt to the dependencies.
This way https://github.com/performous/performous/pull/714 can use this dependency within the container.